### PR TITLE
fix: prevent panic on malformed ISO9660 path table

### DIFF
--- a/iso9660/iso9660.go
+++ b/iso9660/iso9660.go
@@ -198,13 +198,14 @@ func (iso *ISO9660) parsePathTable() error {
 	iso.pathTable = nil
 	i := 0
 	for i < len(pathTableRaw) {
-		if i >= len(pathTableRaw) {
-			break
-		}
-
 		dirNameLen := int(pathTableRaw[i])
 		if dirNameLen == 0 {
 			break
+		}
+
+		// Validate we have enough data for this entry (8 byte header + name)
+		if i+8+dirNameLen > len(pathTableRaw) {
+			return fmt.Errorf("truncated path table entry at offset %d", i)
 		}
 
 		// Extended attribute record length at i+1 (skip)


### PR DESCRIPTION
## Summary
- Add bounds checking in `parsePathTable` to prevent slice bounds out of range panic when parsing malformed ISO9660 images

## Background
The fuzzer found that malformed ISO9660 images with truncated path table entries could cause a panic. The path table entry's `dirNameLen` field could specify a length exceeding the remaining buffer, causing a slice bounds panic.

## Changes
- Validate that `i+8+dirNameLen` doesn't exceed buffer length before slicing
- Return a descriptive error instead of panicking
- Removed redundant bounds check that was after the loop condition

## Test plan
- [x] All existing unit tests pass
- [x] Fuzz test seeds pass
- [x] Lint passes with 0 issues